### PR TITLE
beta3 -> rc

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,7 +7,7 @@ branches:
     - master      # The branch that is published on Nuget.org
 environment:
   packageVersion: 1.0.0
-  versionPrefix: -rc
+  versionPrefix: -rc1
 init:
   - git config --global core.autocrlf true
   - ps: $env:nugetVersion = "$env:packageVersion$env:versionPrefix-$env:appveyor_build_number"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,7 +7,7 @@ branches:
     - master      # The branch that is published on Nuget.org
 environment:
   packageVersion: 1.0.0
-  versionPrefix: -beta3
+  versionPrefix: -rc
 init:
   - git config --global core.autocrlf true
   - ps: $env:nugetVersion = "$env:packageVersion$env:versionPrefix-$env:appveyor_build_number"


### PR DESCRIPTION
Fix #28 
@sebastienros you could merge this after .NET Core 3.0 is shipped

One point is, we can change `rc` to `rc1` if you plan to release more than one RC release
