### PR TITLE
added Dutch translations for OrchardCore.Setup

### DIFF
--- a/Localization/nl/OrchardCore.Setup.po
+++ b/Localization/nl/OrchardCore.Setup.po
@@ -8,25 +8,25 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Language-Team: Dutch\n"
 "Language: nl_NL\n"
-"PO-Revision-Date: 2020-03-31 14:03\n"
+"PO-Revision-Date: 2020-08-05 15:13\n"
 
 #. ModelState.AddModelError(nameof(model.ConnectionString), S["The connection string is mandatory for this provider."]);
 #: OrchardCore.Setup\Controllers\SetupController.cs:105
 msgctxt "OrchardCore.Setup.Controllers.SetupController"
 msgid "The connection string is mandatory for this provider."
-msgstr ""
+msgstr "De verbindingsreeks is verplicht voor deze verschaffer."
 
 #. ModelState.AddModelError(nameof(model.Password), S["The password is required."]);
 #: OrchardCore.Setup\Controllers\SetupController.cs:111
 msgctxt "OrchardCore.Setup.Controllers.SetupController"
 msgid "The password is required."
-msgstr ""
+msgstr "Het wachtwoord is vereist."
 
 #. ModelState.AddModelError(nameof(model.PasswordConfirmation), S["The password confirmation doesn't match the password."]);
 #: OrchardCore.Setup\Controllers\SetupController.cs:116
 msgctxt "OrchardCore.Setup.Controllers.SetupController"
 msgid "The password confirmation doesn't match the password."
-msgstr ""
+msgstr "De bevestiging van het wachtwoord komt niet overeen met het wachtwoord."
 
 #. ModelState.AddModelError(nameof(model.RecipeName), S["Invalid recipe."]);
 #. ModelState.AddModelError(nameof(model.RecipeName), S["Invalid recipe."]);
@@ -34,118 +34,118 @@ msgstr ""
 #: OrchardCore.Setup\Controllers\SetupController.cs:130
 msgctxt "OrchardCore.Setup.Controllers.SetupController"
 msgid "Invalid recipe."
-msgstr ""
+msgstr "Ongeldig recept."
 
 #. ModelState.AddModelError(nameof(model.Email), S["Invalid email."]);
 #: OrchardCore.Setup\Controllers\SetupController.cs:135
 msgctxt "OrchardCore.Setup.Controllers.SetupController"
 msgid "Invalid email."
-msgstr ""
+msgstr "Onjuist email adres."
 
 #. <title>@T["Orchard Setup"]</title>
 #: OrchardCore.Setup\Views\_Layout.cshtml:17
 msgctxt "OrchardCore.Setup.Views._Layout"
 msgid "Orchard Setup"
-msgstr ""
+msgstr "Orchard Opzetten"
 
 #. <label for="culturesList" class="mr-2">@T["Change language"]</label>
 #: OrchardCore.Setup\Views\_Layout.cshtml:33
 msgctxt "OrchardCore.Setup.Views._Layout"
 msgid "Change language"
-msgstr ""
+msgstr "Verander taal"
 
 #: OrchardCore.Setup\Views\Setup\Index.cshtml:0
 msgctxt "OrchardCore.Setup.Views.Setup.Index"
 msgid "one non-alphanumeric"
-msgstr ""
+msgstr "een niet alfanumeriek teken"
 
 #: OrchardCore.Setup\Views\Setup\Index.cshtml:0
 msgctxt "OrchardCore.Setup.Views.Setup.Index"
 msgid "one uppercase"
-msgstr ""
+msgstr "een hoofdletter"
 
 #: OrchardCore.Setup\Views\Setup\Index.cshtml:0
 msgctxt "OrchardCore.Setup.Views.Setup.Index"
 msgid "one lowercase"
-msgstr ""
+msgstr "een kleine letter"
 
 #: OrchardCore.Setup\Views\Setup\Index.cshtml:0
 msgctxt "OrchardCore.Setup.Views.Setup.Index"
 msgid ", "
-msgstr ""
+msgstr ", "
 
 #: OrchardCore.Setup\Views\Setup\Index.cshtml:0
 msgctxt "OrchardCore.Setup.Views.Setup.Index"
 msgid "one digit"
-msgstr ""
+msgstr "een cijfer"
 
 #: OrchardCore.Setup\Views\Setup\Index.cshtml:0
 msgctxt "OrchardCore.Setup.Views.Setup.Index"
 msgid " and "
-msgstr ""
+msgstr " en "
 
 #: OrchardCore.Setup\Views\Setup\Index.cshtml:0
 msgctxt "OrchardCore.Setup.Views.Setup.Index"
 msgid "{0} characters in total"
-msgstr ""
+msgstr "{0} tekens in totaal"
 
 #: OrchardCore.Setup\Views\Setup\Index.cshtml:0
 msgctxt "OrchardCore.Setup.Views.Setup.Index"
 msgid ", with {0} unique characters"
-msgstr ""
+msgstr ", met {0} unieke tekens"
 
 #: OrchardCore.Setup\Views\Setup\Index.cshtml:0
 msgctxt "OrchardCore.Setup.Views.Setup.Index"
 msgid "Password must have at least {0}."
-msgstr ""
+msgstr "Wachtwoord moet tenminste {0} bevatten."
 
 #. <h1>@T["Setup"]</h1>
 #: OrchardCore.Setup\Views\Setup\Index.cshtml:68
 msgctxt "OrchardCore.Setup.Views.Setup.Index"
 msgid "Setup"
-msgstr ""
+msgstr "Opzetten"
 
 #. <p class="lead">@T["Please answer a few questions to configure your site."]</p>
 #: OrchardCore.Setup\Views\Setup\Index.cshtml:69
 msgctxt "OrchardCore.Setup.Views.Setup.Index"
 msgid "Please answer a few questions to configure your site."
-msgstr ""
+msgstr "Beantwoord a.u.b. een paar vragen om je website te configureren."
 
 #. <strong>@T["No recipes available."]</strong> @T["It is not possible to set up a site without a recipe."]
 #: OrchardCore.Setup\Views\Setup\Index.cshtml:75
 msgctxt "OrchardCore.Setup.Views.Setup.Index"
 msgid "No recipes available."
-msgstr ""
+msgstr "Geen recepten beschikbaar."
 
 #. <strong>@T["No recipes available."]</strong> @T["It is not possible to set up a site without a recipe."]
 #: OrchardCore.Setup\Views\Setup\Index.cshtml:75
 msgctxt "OrchardCore.Setup.Views.Setup.Index"
 msgid "It is not possible to set up a site without a recipe."
-msgstr ""
+msgstr "Het is niet mogelijk een website op te zetten zonder een recept."
 
 #. <label asp-for="SiteName">@T["What is the name of your site?"]</label>
 #: OrchardCore.Setup\Views\Setup\Index.cshtml:82
 msgctxt "OrchardCore.Setup.Views.Setup.Index"
 msgid "What is the name of your site?"
-msgstr ""
+msgstr "Wat is de naam van je website?"
 
 #. <span asp-validation-for="SiteName" class="text-danger">@T["The site name is required."]</span>
 #: OrchardCore.Setup\Views\Setup\Index.cshtml:84
 msgctxt "OrchardCore.Setup.Views.Setup.Index"
 msgid "The site name is required."
-msgstr ""
+msgstr "De naam van de website is vereist."
 
 #. <span class="text-muted form-text small">@T["This is used as the default title of your pages."]</span>
 #: OrchardCore.Setup\Views\Setup\Index.cshtml:85
 msgctxt "OrchardCore.Setup.Views.Setup.Index"
 msgid "This is used as the default title of your pages."
-msgstr ""
+msgstr "Dit wordt gebruikt als de standaard titel voor de pagina's."
 
 #. <label asp-for="RecipeName">@T["Recipe"]</label>
 #: OrchardCore.Setup\Views\Setup\Index.cshtml:94
 msgctxt "OrchardCore.Setup.Views.Setup.Index"
 msgid "Recipe"
-msgstr ""
+msgstr "Recept"
 
 #. <button id="noRecipeButton" title="@T["No Recipes Available"]" class="btn btn-secondary dropdown-toggle disabled" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
 #. @T["No Recipes Available"]
@@ -153,125 +153,125 @@ msgstr ""
 #: OrchardCore.Setup\Views\Setup\Index.cshtml:99
 msgctxt "OrchardCore.Setup.Views.Setup.Index"
 msgid "No Recipes Available"
-msgstr ""
+msgstr "Geen Recepten Beschikbaar"
 
 #. <span class="text-muted form-text small">@T["Recipes allow you to setup your site with additional pre-configured options, features and settings out of the box."]</span>
 #: OrchardCore.Setup\Views\Setup\Index.cshtml:117
 msgctxt "OrchardCore.Setup.Views.Setup.Index"
 msgid "Recipes allow you to setup your site with additional pre-configured options, features and settings out of the box."
-msgstr ""
+msgstr "Recepten stellen je in staat een website op te zetten met additionele, kant-en-klare, vooraf geconfigureerde opties, functies en instellingen."
 
 #. <label asp-for="SiteTimeZone">@T["Default Time Zone"]</label>
 #: OrchardCore.Setup\Views\Setup\Index.cshtml:123
 msgctxt "OrchardCore.Setup.Views.Setup.Index"
 msgid "Default Time Zone"
-msgstr ""
+msgstr "Standaard Tijd Zone"
 
 #. <span class="text-muted form-text small">@T["Determines the default time zone used when displaying and editing dates and times."]</span>
 #: OrchardCore.Setup\Views\Setup\Index.cshtml:133
 msgctxt "OrchardCore.Setup.Views.Setup.Index"
 msgid "Determines the default time zone used when displaying and editing dates and times."
-msgstr ""
+msgstr "Bepaalt de standaard tijd zone die gebruikt wordt voor het afbeelden en bewerken van data en tijden."
 
 #. @T["Database"]
 #: OrchardCore.Setup\Views\Setup\Index.cshtml:140
 msgctxt "OrchardCore.Setup.Views.Setup.Index"
 msgid "Database"
-msgstr ""
+msgstr "Database"
 
 #. <span class="text-muted form-text small">@T["The database is used to store the site's configuration and its contents. You can specify a custom table prefix if you intend to reuse the same database for multiple sites."]</span>
 #: OrchardCore.Setup\Views\Setup\Index.cshtml:141
 msgctxt "OrchardCore.Setup.Views.Setup.Index"
 msgid "The database is used to store the site's configuration and its contents. You can specify a custom table prefix if you intend to reuse the same database for multiple sites."
-msgstr ""
+msgstr "De database wordt gebruikt om de website's instelling en inhoud op te slaan. Je kunt een aangepast tabel voorvoegsel opgeven als je van plan bent dezelfde database te gebruiken voor meerdere websites."
 
 #. <label asp-for="DatabaseProvider">@T["What type of database to use?"]</label>
 #: OrchardCore.Setup\Views\Setup\Index.cshtml:145
 msgctxt "OrchardCore.Setup.Views.Setup.Index"
 msgid "What type of database to use?"
-msgstr ""
+msgstr "Welk type database zal gebruikt worden?"
 
 #. <option value="@provider.Value" data-connection-string="@provider.HasConnectionString" data-table-prefix="@provider.HasTablePrefix" data-connection-string-sample="@T["The connection string to your database instance. e.g., {0}", provider.SampleConnectionString]">@provider.Name</option>
 #: OrchardCore.Setup\Views\Setup\Index.cshtml:149
 msgctxt "OrchardCore.Setup.Views.Setup.Index"
 msgid "The connection string to your database instance. e.g., {0}"
-msgstr ""
+msgstr "De verbindingsreeks naar je database instantie. Bijvoorbeeld: {0}"
 
 #. <label asp-for="TablePrefix">@T["Table Prefix"]</label>
 #: OrchardCore.Setup\Views\Setup\Index.cshtml:156
 msgctxt "OrchardCore.Setup.Views.Setup.Index"
 msgid "Table Prefix"
-msgstr ""
+msgstr "Tabel Voorvoegsel"
 
 #. <label asp-for="ConnectionString">@T["Connection string"]</label>
 #: OrchardCore.Setup\Views\Setup\Index.cshtml:164
 msgctxt "OrchardCore.Setup.Views.Setup.Index"
 msgid "Connection string"
-msgstr ""
+msgstr "Verbindingsreeks"
 
 #. <div class="input-group-append reveal" title="@T["Show/hide connection string"]">
 #: OrchardCore.Setup\Views\Setup\Index.cshtml:168
 msgctxt "OrchardCore.Setup.Views.Setup.Index"
 msgid "Show/hide connection string"
-msgstr ""
+msgstr "Toon/Verberg de verbindingsreeks"
 
 #. @T["Super User"]
 #: OrchardCore.Setup\Views\Setup\Index.cshtml:179
 msgctxt "OrchardCore.Setup.Views.Setup.Index"
 msgid "Super User"
-msgstr ""
+msgstr "Super Gebruiker"
 
 #. <span class="text-muted form-text small">@T["The super user has all the rights. It should be used only during Setup and for disaster recovery."]</span>
 #: OrchardCore.Setup\Views\Setup\Index.cshtml:180
 msgctxt "OrchardCore.Setup.Views.Setup.Index"
 msgid "The super user has all the rights. It should be used only during Setup and for disaster recovery."
-msgstr ""
+msgstr "De super gebruiker heel alle rechten. Het is beter om deze gebruiker alleen te gebruiken bij het opzetten van de website en bij noodherstel."
 
 #. <label asp-for="UserName">@T["User name"]</label>
 #: OrchardCore.Setup\Views\Setup\Index.cshtml:184
 msgctxt "OrchardCore.Setup.Views.Setup.Index"
 msgid "User name"
-msgstr ""
+msgstr "Gebruikersnaam"
 
 #. <span asp-validation-for="UserName" class="text-danger">@T["The user name is required."]</span>
 #: OrchardCore.Setup\Views\Setup\Index.cshtml:186
 msgctxt "OrchardCore.Setup.Views.Setup.Index"
 msgid "The user name is required."
-msgstr ""
+msgstr "De gebruikersnaam is vereist."
 
 #. <label for="Email">@T["Email"]</label>
 #: OrchardCore.Setup\Views\Setup\Index.cshtml:189
 msgctxt "OrchardCore.Setup.Views.Setup.Index"
 msgid "Email"
-msgstr ""
+msgstr "Email adres"
 
 #. <span asp-validation-for="Email" class="text-danger">@T["The email is invalid."]</span>
 #: OrchardCore.Setup\Views\Setup\Index.cshtml:191
 msgctxt "OrchardCore.Setup.Views.Setup.Index"
 msgid "The email is invalid."
-msgstr ""
+msgstr "Het email adres is onjuist."
 
 #. <label asp-for="Password">@T["Password"]</label>
 #: OrchardCore.Setup\Views\Setup\Index.cshtml:197
 msgctxt "OrchardCore.Setup.Views.Setup.Index"
 msgid "Password"
-msgstr ""
+msgstr "Wachtwoord"
 
 #. <input asp-for="Password" type="password" class="form-control" data-toggle="popover" data-placement="top" data-trigger="focus" data-title="@T["Password strength"]" data-content="@passwordTooltip" required pattern="@passwordRegex" />
 #: OrchardCore.Setup\Views\Setup\Index.cshtml:198
 msgctxt "OrchardCore.Setup.Views.Setup.Index"
 msgid "Password strength"
-msgstr ""
+msgstr "Wachtwoord sterkte"
 
 #. <label asp-for="PasswordConfirmation">@T["Password Confirmation"]</label>
 #: OrchardCore.Setup\Views\Setup\Index.cshtml:204
 msgctxt "OrchardCore.Setup.Views.Setup.Index"
 msgid "Password Confirmation"
-msgstr ""
+msgstr "Wachtwoord Bevestiging"
 
 #. <button class="btn btn-primary" type="submit" id="SubmitButton">@T["Finish Setup"]</button>
 #: OrchardCore.Setup\Views\Setup\Index.cshtml:211
 msgctxt "OrchardCore.Setup.Views.Setup.Index"
 msgid "Finish Setup"
-msgstr ""
+msgstr "Voltooi Opzetten"
 


### PR DESCRIPTION
Noticed the setup page is available in several languages and Dutch (Nederlands, Netherlands NL/nl) was missing.