### PR TITLE
Enable meta package for Macedonian (mk) culture

### DIFF
--- a/cultures.json
+++ b/cultures.json
@@ -112,7 +112,7 @@
     "name": "mk",
     "display-name": "Macedonian",
     "generate-package": true,
-    "meta-package": false
+    "meta-package": true
   },
   {
     "name": "nb-NO",


### PR DESCRIPTION
@agriffard `mk` culture now has 51% of total translations which good to ship it in the meta package