### PR TITLE
Add workflow_dispatch trigger to publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,8 +4,14 @@ name: Publish Stable Packages
 
 on:
   push:
-    tags: 
+    tags:
       - 'v*.*.*'
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Package version to publish (e.g. 3.0.0)'
+        required: true
+        type: string
 
 jobs:
   build:
@@ -21,8 +27,12 @@ jobs:
 
     - name: Build version number
       run: |
-        arrTag=(${GITHUB_REF//\// })
-        VERSION="${arrTag[2]}"
+        if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+          VERSION="${{ github.event.inputs.version }}"
+        else
+          arrTag=(${GITHUB_REF//\// })
+          VERSION="${arrTag[2]}"
+        fi
         VERSION="${VERSION//v}"
         echo "$VERSION"
         echo "nugetVersion=$VERSION" >> $GITHUB_ENV


### PR DESCRIPTION
## Why

Tagging `v3.0.0` did not trigger the publish workflow. Investigation shows the publish workflow has **zero runs in its entire history** (`GET /actions/workflows/11267006/runs` → `total_count: 0`), so tag pushes have never spawned a run, even though:

- the tag matches the `v*.*.*` pattern,
- `publish.yml` exists at the tagged commit,
- the workflow state is `active` and Actions are enabled for the repo.

Deleting and re-pushing the tag from the CLI did not help either. Other push-triggered workflows (e.g. `stage.yml`) also stopped firing after June 3, while Actions in OrchardCMS/OrchardCore run fine — so this looks repo-specific and worth a GitHub support ticket.

## What

Adds a `workflow_dispatch` trigger with a required `version` input so stable packages can be published manually (Actions → Publish Stable Packages → Run workflow → `3.0.0`), unblocking the 3.0.0 release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)